### PR TITLE
helm: fix volumes when specifying aws credentials file

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -151,7 +151,7 @@ spec:
       hostNetwork: {{ .Values.deployment.hostNetwork }}
       dnsPolicy: {{ .Values.deployment.dnsPolicy }}
       volumes:
-      {{- if .Values.aws.credentials.secretName -}}
+      {{- if .Values.aws.credentials.secretName }}
         - name: {{ .Values.aws.credentials.secretName }}
           secret:
             secretName: {{ .Values.aws.credentials.secretName }}


### PR DESCRIPTION
# Description of changes:

Currently, if you specify AWS credentials using the `aws.credentials.secretName` setting, the chart will render an invalid `volumes` field in the deployment:
```yaml
[...]
volumes:- name: aws-creds
          secret:
            secretName: aws-creds
```

This PR is fixing this by removing the `-` at the end of the Helm `if` statement that is removing the newline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
