### PR TITLE
fix: parameter order on tag updates

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-06-25T18:55:23Z"
-  build_hash: a488d4e8a9222ed51e5690cb5850beb21cce5a1f
-  go_version: go1.24.3
-  version: v0.48.0-1-ga488d4e-dirty
+  build_date: "2025-06-27T16:02:54Z"
+  build_hash: 7db573dd591b1dc817d9223710b6c7031d31364c
+  go_version: go1.24.4
+  version: v0.48.0-2-g7db573d
 api_directory_checksum: b4eb4c1d6104667453456af5144ca269b1af8965
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/pkg/resource/secret/sdk.go
+++ b/pkg/resource/secret/sdk.go
@@ -340,8 +340,8 @@ func (rm *resourceManager) sdkUpdate(
 	if delta.DifferentAt("Spec.Tags") {
 		err := rm.syncTags(
 			ctx,
-			latest,
 			desired,
+			latest,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/resource/tags/sync.go
+++ b/pkg/resource/tags/sync.go
@@ -40,8 +40,8 @@ func SyncResourceTags(
 	client tagsClient,
 	mr metricsRecorder,
 	resourceARN string,
-	latestTags []*svcapitypes.Tag,
 	desiredTags []*svcapitypes.Tag,
+	latestTags []*svcapitypes.Tag,
 ) error {
 
 	var err error

--- a/templates/hooks/secret/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/secret/sdk_update_pre_build_request.go.tpl
@@ -1,8 +1,8 @@
 if delta.DifferentAt("Spec.Tags") {
     err := rm.syncTags(
         ctx,
-        latest,
         desired,
+        latest,
     )
     if err != nil {
         return nil, err


### PR DESCRIPTION
Issue [#2543](https://github.com/aws-controllers-k8s/community/issues/2543)

Description of changes:
Fix the parameter order when updating tags, (caused panics)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
