### PR TITLE
chore: make a list call before readOne if ID not populated

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-06-27T16:02:54Z"
-  build_hash: 7db573dd591b1dc817d9223710b6c7031d31364c
+  build_date: "2025-07-14T18:25:01Z"
+  build_hash: 49a32e72777469d874a917cf1da21809d988dccc
   go_version: go1.24.4
-  version: v0.48.0-2-g7db573d
+  version: v0.48.0-2-g49a32e7
 api_directory_checksum: b4eb4c1d6104667453456af5144ca269b1af8965
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: a8b36d01f48647127e8a899eee1dfc6c6c804707
+  file_checksum: a676fc52b34b88278c3f4716573ec2868e67aa13
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -11,6 +11,8 @@ resources:
         template_path: hooks/secret/sdk_read_one_pre_set_output.go.tpl
       sdk_update_pre_build_request:
         template_path: hooks/secret/sdk_update_pre_build_request.go.tpl
+      sdk_read_one_pre_build_request:
+        template_path: hooks/secret/sdk_read_one_pre_build_request.go.tpl
     fields:
       ID:
         from:

--- a/generator.yaml
+++ b/generator.yaml
@@ -11,6 +11,8 @@ resources:
         template_path: hooks/secret/sdk_read_one_pre_set_output.go.tpl
       sdk_update_pre_build_request:
         template_path: hooks/secret/sdk_update_pre_build_request.go.tpl
+      sdk_read_one_pre_build_request:
+        template_path: hooks/secret/sdk_read_one_pre_build_request.go.tpl
     fields:
       ID:
         from:

--- a/pkg/resource/secret/sdk.go
+++ b/pkg/resource/secret/sdk.go
@@ -63,6 +63,13 @@ func (rm *resourceManager) sdkFind(
 	defer func() {
 		exit(err)
 	}()
+	if rm.requiredFieldsMissingFromReadOneInput(r) {
+		r.ko.Status.ID, err = rm.getSecretID(ctx, r)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. Return NotFound here to indicate to callers that the
 	// resource isn't yet created.

--- a/templates/hooks/secret/sdk_read_one_pre_build_request.go.tpl
+++ b/templates/hooks/secret/sdk_read_one_pre_build_request.go.tpl
@@ -1,0 +1,6 @@
+	if rm.requiredFieldsMissingFromReadOneInput(r) {
+		err = rm.attemptFindingByName(ctx, r)
+        if err != nil {
+            return nil, err
+        }
+	}


### PR DESCRIPTION
Issue [#2489](https://github.com/aws-controllers-k8s/community/issues/2489)

Description of changes:
The secretsmanager controller assumes a secret does not exist if the
Status.ID is empty. During adoption, users might want to adopt the
resource by its name, as the ID is not trivial to guess (the secret ARN,
with some generated hash appended to the name).

These changes are adding one API call only when the Status.ID is empty.
Here we would make a single List call filtering by name, and populate
the resource ID, to be used in subsequent API calls

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
