### PR TITLE
Require exact name match in getSecretID to avoid mis-adoption

### DIFF
--- a/pkg/resource/secret/hooks.go
+++ b/pkg/resource/secret/hooks.go
@@ -55,15 +55,35 @@ func (rm *resourceManager) getSecretID(
 		return nil, nil
 	}
 
-	resp, err := rm.sdkapi.ListSecrets(ctx, &svcsdk.ListSecretsInput{Filters: []svcsdktypes.Filter{{Key: "name", Values: []string{*r.ko.Spec.Name}}}})
-	if err != nil {
-		return nil, err
+	// The AWS Secrets Manager `ListSecrets` filter with key "name" is a
+	// prefix match (case-insensitive) rather than an exact match. Iterating
+	// over all pages and keeping only the entry whose Name is strictly equal
+	// to Spec.Name prevents adopting an unrelated secret whose name happens
+	// to start with the same prefix (e.g. Spec.Name="dev/app" silently
+	// adopting the existing AWS secret "dev/app-service").
+	input := &svcsdk.ListSecretsInput{
+		Filters: []svcsdktypes.Filter{{
+			Key:    "name",
+			Values: []string{*r.ko.Spec.Name},
+		}},
 	}
 
-	if resp == nil || len(resp.SecretList) == 0 {
-		return nil, nil
+	for {
+		resp, err := rm.sdkapi.ListSecrets(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		if resp == nil {
+			return nil, nil
+		}
+		for _, s := range resp.SecretList {
+			if s.Name != nil && *s.Name == *r.ko.Spec.Name {
+				return s.ARN, nil
+			}
+		}
+		if resp.NextToken == nil || *resp.NextToken == "" {
+			return nil, nil
+		}
+		input.NextToken = resp.NextToken
 	}
-
-	return resp.SecretList[0].ARN, nil
-
 }

--- a/pkg/resource/secret/hooks.go
+++ b/pkg/resource/secret/hooks.go
@@ -55,12 +55,6 @@ func (rm *resourceManager) getSecretID(
 		return nil, nil
 	}
 
-	// The AWS Secrets Manager `ListSecrets` filter with key "name" is a
-	// prefix match (case-insensitive) rather than an exact match. Iterating
-	// over all pages and keeping only the entry whose Name is strictly equal
-	// to Spec.Name prevents adopting an unrelated secret whose name happens
-	// to start with the same prefix (e.g. Spec.Name="dev/app" silently
-	// adopting the existing AWS secret "dev/app-service").
 	input := &svcsdk.ListSecretsInput{
 		Filters: []svcsdktypes.Filter{{
 			Key:    "name",


### PR DESCRIPTION
## Problem

When a `Secret` CR is reconciled (using `adopt-or-create` annotation) for the first time with `spec.name` set but `status.id` empty, `sdkFind` invokes `getSecretID` which calls AWS `ListSecrets` with a `Filter{Key:"name", Values:[spec.name]}`. The current code returns `resp.SecretList[0].ARN` unconditionally.

The AWS Secrets Manager `ListSecrets` name filter is a **prefix match, case-insensitive**, not an exact match (see [Filter docs](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_Filter.html)). As a result, if an AWS secret whose name merely starts with `spec.name` already exists, the controller silently adopts it: `Status.ID` is set to that unrelated ARN, and every subsequent `DescribeSecret`/`UpdateSecret`/`DeleteSecret` targets the wrong secret.

This also leads to multiple CRs adopting the same AWS ARN and fighting over its content at every reconcile (write war, silent drift of secret material, risk of deleting an unrelated production secret when a CR is removed).

## Fix

In `getSecretID`, iterate all pages of \`ListSecrets\` (via \`NextToken\`) and return an ARN only when the entry's \`Name\` is strictly equal to \`Spec.Name\`. If no exact match is found, return \`(nil, nil)\` so that \`sdkFind\` returns \`NotFound\` and the runtime proceeds to \`CreateSecret\` — the intended behavior when the named secret does not yet exist. 

UPDATE: The fix works perfectly for use-case in the dev environment, after building a local docker image. 