### PR TITLE
feat: update secretString on secret ref changes

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-05-19T18:46:47Z"
-  build_hash: e581e886276bd781409a3fb11fa665ea31de17d4
-  go_version: go1.26.3
-  version: v0.59.1
-api_directory_checksum: e152e0252a829e20267541658a21e78ff62e7a8b
+  build_date: "2026-05-26T19:20:33Z"
+  build_hash: 45fc6c24a809921c7d7305c51dc9e06831b355d6
+  go_version: go1.26.0
+  version: v0.59.1-2-g45fc6c2
+api_directory_checksum: e9577bc9f7bcf471aa88fb0145d820a7efbb6a17
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 865d3df5f5839d85990ced71f51b58a44bdfa64b
+  file_checksum: 425bdf22e5ce9b31b873df5174455e5e16b7a51d
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/annotation.go
+++ b/apis/v1alpha1/annotation.go
@@ -1,0 +1,30 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package v1alpha1
+
+import "fmt"
+
+var (
+	// LastAppliedSecretAnnotation is the annotation key used to store the
+	// namespaced name of the last used secret for setting the SecretString.
+	//
+	// The secret namespaced name stored in this annotation is used to compute
+	// the "reference" delta when the user updates the Secret resource.
+	//
+	// This annotation is only applied by the secretsmanager-controller, and
+	// should not be modified by the user. In case the user modifies this
+	// annotation, the controller may not be able to correctly compute the
+	// "reference" delta, and can result in unnecessary SecretString updates.
+	LastAppliedSecretAnnotation = fmt.Sprintf("%s/last-applied-secret-reference", GroupVersion.Group)
+)

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -5,12 +5,18 @@ ignore:
 resources:
   Secret:
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
       sdk_create_pre_set_output:
         template_path: hooks/secret/sdk_create_pre_set_output.go.tpl
+      sdk_create_post_set_output:
+        template_path: hooks/secret/sdk_create_post_set_output.go.tpl
       sdk_read_one_pre_set_output:
         template_path: hooks/secret/sdk_read_one_pre_set_output.go.tpl
       sdk_update_pre_build_request:
         template_path: hooks/secret/sdk_update_pre_build_request.go.tpl
+      sdk_update_post_set_output:
+        template_path: hooks/secret/sdk_update_post_set_output.go.tpl
       sdk_read_one_pre_build_request:
         template_path: hooks/secret/sdk_read_one_pre_build_request.go.tpl
     fields:

--- a/generator.yaml
+++ b/generator.yaml
@@ -5,12 +5,18 @@ ignore:
 resources:
   Secret:
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
       sdk_create_pre_set_output:
         template_path: hooks/secret/sdk_create_pre_set_output.go.tpl
+      sdk_create_post_set_output:
+        template_path: hooks/secret/sdk_create_post_set_output.go.tpl
       sdk_read_one_pre_set_output:
         template_path: hooks/secret/sdk_read_one_pre_set_output.go.tpl
       sdk_update_pre_build_request:
         template_path: hooks/secret/sdk_update_pre_build_request.go.tpl
+      sdk_update_post_set_output:
+        template_path: hooks/secret/sdk_update_post_set_output.go.tpl
       sdk_read_one_pre_build_request:
         template_path: hooks/secret/sdk_read_one_pre_build_request.go.tpl
     fields:

--- a/pkg/resource/secret/delta.go
+++ b/pkg/resource/secret/delta.go
@@ -41,6 +41,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customPreCompare(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.Description, b.ko.Spec.Description) {
 		delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)

--- a/pkg/resource/secret/hooks.go
+++ b/pkg/resource/secret/hooks.go
@@ -15,13 +15,54 @@ package secret
 
 import (
 	"context"
+	"fmt"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 
+	svcapitypes "github.com/aws-controllers-k8s/secretsmanager-controller/apis/v1alpha1"
 	"github.com/aws-controllers-k8s/secretsmanager-controller/pkg/resource/tags"
 )
+
+func customPreCompare(delta *ackcompare.Delta, a, b *resource) {
+	compareSecretReferenceChanges(delta, a, b)
+}
+
+func getLastAppliedSecretReferenceString(r *ackv1alpha1.SecretKeyReference) string {
+	if r == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s.%s", r.Namespace, r.Name, r.Key)
+}
+
+func setLastAppliedSecretReferenceAnnotation(r *resource) {
+	if r.ko.Annotations == nil {
+		r.ko.Annotations = make(map[string]string)
+	}
+	r.ko.Annotations[svcapitypes.LastAppliedSecretAnnotation] = getLastAppliedSecretReferenceString(r.ko.Spec.SecretString)
+}
+
+func getLastAppliedSecretReferenceAnnotation(r *resource) string {
+	if r.ko.Annotations == nil {
+		return ""
+	}
+	return r.ko.Annotations[svcapitypes.LastAppliedSecretAnnotation]
+}
+
+func compareSecretReferenceChanges(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	oldRef := getLastAppliedSecretReferenceAnnotation(a)
+	newRef := getLastAppliedSecretReferenceString(a.ko.Spec.SecretString)
+	if oldRef != newRef {
+		delta.Add("Spec.SecretString", oldRef, newRef)
+	}
+}
 
 // syncTags keeps the resource's tags in sync.
 func (rm *resourceManager) syncTags(

--- a/pkg/resource/secret/sdk.go
+++ b/pkg/resource/secret/sdk.go
@@ -267,6 +267,9 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+	r := &resource{ko}
+	setLastAppliedSecretReferenceAnnotation(r)
+
 	return &resource{ko}, nil
 }
 
@@ -392,6 +395,9 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	rm.setStatusDefaults(ko)
+	r := &resource{ko}
+	setLastAppliedSecretReferenceAnnotation(r)
+
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/secret/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/secret/sdk_create_post_set_output.go.tpl
@@ -1,0 +1,2 @@
+	r := &resource{ko}
+	setLastAppliedSecretReferenceAnnotation(r)

--- a/templates/hooks/secret/sdk_update_post_set_output.go.tpl
+++ b/templates/hooks/secret/sdk_update_post_set_output.go.tpl
@@ -1,0 +1,2 @@
+	r := &resource{ko}
+	setLastAppliedSecretReferenceAnnotation(r)

--- a/test/e2e/tests/test_secret.py
+++ b/test/e2e/tests/test_secret.py
@@ -122,6 +122,57 @@ class TestSecret:
         "simple_secret",
         [
             {
+                "name": "secret-string-update",
+            },
+        ],
+        indirect=True,
+    )
+    def test_secret_string_update(self, secretsmanager_client, k8s_secret, simple_secret):
+        (res, ref) = simple_secret
+
+        time.sleep(5)
+
+        cr = k8s.get_resource(ref)
+        assert cr is not None
+        assert 'spec' in cr
+        assert 'name' in cr["spec"]
+
+        secret_name = cr['spec']['name']
+        secretsmanager_validator = SecretsManagerValidator(secretsmanager_client)
+
+        # Verify initial secret value
+        expected_value = '{"env":"test"}'
+        secretsmanager_validator.assert_secret_value(secret_name, expected_value)
+
+        # Create a new K8s secret with an updated value
+        new_secret_val = '{"env":"production"}'
+        new_secret = k8s_secret(
+            "default",
+            random_suffix_name("updated-secret", 24),
+            "secret_str_key",
+            new_secret_val,
+        )
+
+        # Update the CR's secretString reference to point to the new K8s secret
+        updates = {
+            "spec": {
+                "secretString": {
+                    "name": new_secret.name,
+                    "namespace": new_secret.ns,
+                    "key": new_secret.key,
+                },
+            },
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS)
+
+        # Verify the secret value was updated in AWS
+        secretsmanager_validator.assert_secret_value(secret_name, new_secret_val)
+
+    @pytest.mark.parametrize(
+        "simple_secret",
+        [
+            {
                 "name": "tag-secret",
             },
         ],


### PR DESCRIPTION
Issue [#2205](https://github.com/aws-controllers-k8s/community/issues/2205)

Description of changes:
Currently, the only way to update the secretString is to update another
field besides tags. This is not a desirable solution for someone who
wants to update the secretString of their Secret. With these changes, we
ensure the controller always updates the SecretString from the
SecretReference, since the secret value is not returned by the API for
comparison.

In the future, we can explore a more targeted approach: watching for
changes to the referenced Kubernetes Secret and triggering the update
only when it is modified, along with a better delta check to avoid
unconditional updates on every resync.

This is the same solution used for RDS passwords https://github.com/aws-controllers-k8s/rds-controller/pull/170

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
